### PR TITLE
8 - Set disabled status in set_tenant

### DIFF
--- a/lib/rls_rails/helpers.rb
+++ b/lib/rls_rails/helpers.rb
@@ -41,7 +41,7 @@ module RLS
     clear_query_cache
     debug_print "Accessing database as #{tenant.name}\n"
     execute_sql "SET SESSION rls.disable = FALSE; SET SESSION rls.tenant_id = #{tenant.id};"
-    @rls_status.merge!(tenant_id: tenant.id.to_s)
+    @rls_status.merge!(tenant_id: tenant.id.to_s, disabled: 'false')
   end
 
   def self.set_user user


### PR DESCRIPTION
Set disabled status in set_tenant

### Before fix
RLS.set_tenant Tenant.find(33)
=> {:user_id=>"", :tenant_id=>"33", :disabled=>"true"}

2.6.6 :026 > RLS.disabled?
=> false

### After fix

RLS.set_tenant Tenant.find(33)
=> {:user_id=>"", :tenant_id=>"33", :disabled=>"false"}

2.6.6 :026 > RLS.disabled?
=> false