### PR TITLE
Fix debug print that expects a name attribute on the tenant

### DIFF
--- a/lib/rls_rails/helpers.rb
+++ b/lib/rls_rails/helpers.rb
@@ -39,7 +39,7 @@ module RLS
     return if self.status[:tenant_id] === tenant.id&.to_s && enabled?
 
     clear_query_cache
-    debug_print "Accessing database as #{tenant.name}\n"
+    debug_print "Accessing database as #{tenant.try(:name) || "tenant id #{tenant.id}"}\n"
     execute_sql "SET SESSION rls.disable = FALSE; SET SESSION rls.tenant_id = #{tenant.id};"
     @rls_status.merge!(tenant_id: tenant.id.to_s)
   end


### PR DESCRIPTION
Small fix to not assume that the tenant model being used has a `name` attribute.