### PR TITLE
Add support to automatically use a non-privileged role

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,13 @@ If you wondering if there are currently any tables without policies, you can che
 `SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND NOT rowsecurity`.
 
 
+## Database user/role permissions
+
+If the database user used for your application has either `SUPERUSER` or `BYPASSRLS`, then RLS policies will not be enforced. You can remove these attributes from your database user, but a caution that you may need to tweak other permissions so database migrations and other typical "superuser" tasks still work.
+
+Alternatively, you can set `config.unprivileged_db_role` to another database role that does not have these attributes.  Your primary database role will still be used for migrations, but as soon as a tenant is set, the role is switched for that session.  This also avoids the issue of a table owner bypassing RLS by default.
+
+
 ## Future Work
 
 ### Testing Policies

--- a/lib/generators/rls_rails/install/install_generator.rb
+++ b/lib/generators/rls_rails/install/install_generator.rb
@@ -18,6 +18,7 @@ RLS.configure do |config|
   config.tenant_class = Tenant
   config.tenant_fk = :tenant_id
   config.policy_dir = 'db/policies'
+  config.unprivileged_db_role = nil
 end
       RUBY
     end

--- a/lib/generators/rls_rails/install_generator.rb
+++ b/lib/generators/rls_rails/install_generator.rb
@@ -18,6 +18,7 @@ RLS.configure do |config|
   config.tenant_class = Tenant
   config.tenant_fk = :tenant_id
   config.policy_dir = 'db/policies'
+  config.unprivileged_db_role = nil
 end
       RUBY
     end

--- a/lib/rls_rails/helpers.rb
+++ b/lib/rls_rails/helpers.rb
@@ -11,6 +11,7 @@ module RLS
 
     clear_query_cache
     execute_sql("SET SESSION rls.disable = TRUE;")
+    set_role(privileged: true)
     @rls_status.merge!(disabled: 'true')
     debug_print "WARNING: ROW LEVEL SECURITY DISABLED!\n"
   end
@@ -26,6 +27,7 @@ module RLS
 
     clear_query_cache
     debug_print "ROW LEVEL SECURITY ENABLED!\n"
+    set_role(privileged: false)
     execute_sql("SET SESSION rls.disable = FALSE;")
     @rls_status.merge!(disabled: 'false')
   end
@@ -41,6 +43,7 @@ module RLS
     clear_query_cache
     debug_print "Accessing database as #{tenant.name}\n"
     execute_sql "SET SESSION rls.disable = FALSE; SET SESSION rls.tenant_id = #{tenant.id};"
+    set_role(privileged: false)
     @rls_status.merge!(tenant_id: tenant.id.to_s)
   end
 
@@ -51,6 +54,7 @@ module RLS
     clear_query_cache
     debug_print "Accessing database as #{user.class}##{user.id}\n"
     execute_sql "SET SESSION rls.disable = FALSE; SET SESSION rls.user_id = #{user.id};"
+    set_role(privileged: false)
     @rls_status.merge!(user_id: user.id.to_s)
   end
 
@@ -70,6 +74,7 @@ module RLS
       RESET rls.tenant_id;
       RESET rls.disable;
     SQL
+    set_role(privileged: false)
     clear_query_cache
     @rls_status.merge!(tenant_id: '', user_id: '', disabled: '')
   end
@@ -89,6 +94,7 @@ module RLS
       SET SESSION rls.user_id   = '#{user_id}';
       SET SESSION rls.tenant_id = '#{tenant_id}';
     SQL
+    set_role(privileged: status[:disable] && status[:disable] != 'false')
     @rls_status.merge!(tenant_id: tenant_id, user_id: user_id, disabled: disable)
   end
 
@@ -150,12 +156,26 @@ module RLS
     end
   end
 
+  def self.set_role(privileged: false)
+    return unless unprivileged_db_role.present?
+
+    if privileged
+      execute_sql('SET ROLE NONE;')
+    else
+      execute_sql("SET ROLE #{unprivileged_db_role};")
+    end
+  end
+
   def self.tenant_class
     Railtie.config.rls_rails.tenant_class
   end
 
   def self.user_class
     Railtie.config.rls_rails.user_class
+  end
+
+  def self.unprivileged_db_role
+    Railtie.config.rls_rails.unprivileged_db_role
   end
 
   private

--- a/lib/rls_rails/railtie.rb
+++ b/lib/rls_rails/railtie.rb
@@ -13,6 +13,7 @@ module RLS
     config.rls_rails.user_class = nil
     config.rls_rails.tenant_fk = :tenant_id
     config.rls_rails.verbose = false
+    config.rls_rails.unprivileged_db_role = nil
 
     initializer "rls_rails.load" do
       ActiveSupport.on_load :active_record do


### PR DESCRIPTION
While the `force` option for policies solves the issue of a table owner bypassing RLS, we hit other issues removing `SUPERUSER` from the primary database account used for migrations and other tasks.

These changes add an alternative approach where the session is optionally switched to another non-privileged role whenever RLS is enabled.