### PR TITLE
previously set tenant is leaked, when RLS is disabled

### DIFF
--- a/lib/rls_rails/helpers.rb
+++ b/lib/rls_rails/helpers.rb
@@ -56,12 +56,16 @@ module RLS
   end
 
   def self.current_tenant_id
+    return if disabled?
+
     execute_sql(<<-SQL.strip_heredoc).values[0][0].presence
       SELECT current_setting('rls.tenant_id', TRUE);
     SQL
   end
 
   def self.current_user_id
+    return if disabled?
+
     execute_sql(<<-SQL.strip_heredoc).values[0][0].presence
       SELECT current_setting('rls.user_id', TRUE);
     SQL


### PR DESCRIPTION
I frequently check `RLS.current_tenant_id` in my code to check if a current tenant has been specified, and I also use `RLS.disable_for_block` in a few places where no tenant is relevant. I was recently debugging a piece of code that could be run with or without a tenant. In this particular run, I was expecting no tenant to be set, but I noticed that `RLS.current_tenant_id` was set, even though I was within a `RLS.disable_for_block` block and `RLS.disabled?` was `false`. I could check for both `RLS.enabled? && RLS.current_tenant_id`, but I think it would be less error-prone to return `nil` for `RLS.current_tenant_id` and `RLS.current_user_id` if `RLS.disabled?` is `true`.

What do you think? Happy to push this further, if you think this could be improved more.

Thanks!